### PR TITLE
Updated LocationReporter interface to better support asynchronous reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
 
 	<groupId>com.coalminesoftware</groupId>
 	<artifactId>location-tracer</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<packaging>jar</packaging>
 
 	<name>Location Tracer</name>
-	<url>https://github.com/coalminesoftware/LocationTracer</url>
+	<url>https://github.com/CoalMineSoftware/LocationTracer</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/coalminesoftware/locationtracer/LocationTracer.java
+++ b/src/main/java/com/coalminesoftware/locationtracer/LocationTracer.java
@@ -207,7 +207,7 @@ public class LocationTracer<StorageLocation> {
 	private void reportStoredLocations() {
 		if(locationStore.getLocationCount() > 0) {
 			List<StorageLocation> locations = locationStore.getLocations();
-			locationReporter.reportLocations(locations, new LocationRemovingReportCompletionNotifier<StorageLocation>(locationStore));
+			locationReporter.reportLocations(locations, new LocationRemovingReportCompletionHandler<StorageLocation>(locationStore));
 		}
 	}
 
@@ -309,10 +309,10 @@ public class LocationTracer<StorageLocation> {
 	/**
 	 * {@link ReportCompletionHandler} implementation that removes locations from the store once reported.
 	 */
-	private static class LocationRemovingReportCompletionNotifier<StorageLocation> implements ReportCompletionHandler<StorageLocation> {
+	private static class LocationRemovingReportCompletionHandler<StorageLocation> implements ReportCompletionHandler<StorageLocation> {
 		private final WeakReference<LocationStore<StorageLocation>> storeReference;
 		
-		public LocationRemovingReportCompletionNotifier(LocationStore<StorageLocation> locationStore) {
+		public LocationRemovingReportCompletionHandler(LocationStore<StorageLocation> locationStore) {
 			storeReference = new WeakReference<LocationStore<StorageLocation>>(locationStore);
 		}
 

--- a/src/main/java/com/coalminesoftware/locationtracer/reporting/LocationReporter.java
+++ b/src/main/java/com/coalminesoftware/locationtracer/reporting/LocationReporter.java
@@ -1,5 +1,6 @@
 package com.coalminesoftware.locationtracer.reporting;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface LocationReporter<StorageLocation> {
@@ -9,5 +10,13 @@ public interface LocationReporter<StorageLocation> {
 	 * @param locations Locations to report.
 	 * @return The locations that were successfully reported.
 	 */
-	List<StorageLocation> reportLocations(List<StorageLocation> locations);
+	void reportLocations(List<StorageLocation> locations, ReportCompletionHandler<StorageLocation> reportCompletionNotifier);
+
+	/**
+	 * Used by {@link LocationReporter} implementers to notify the library that the locations
+	 * provided to {@link LocationReporter#reportLocations(List)} were successfully reported.
+	 */
+	public interface ReportCompletionHandler<StorageLocation> {
+		void onLocationReportComplete(Collection<StorageLocation> reportedLocations);
+	}
 }


### PR DESCRIPTION
Previously, the `LocationReporter` interface had implementers return a `List` of the locations it successfully reported, which would then be removed from the cache. However, because locations will likely be uploaded over a network and it's a best practice to make network requests asynchronously, rather than returning a list of successfully reported locations, reporters are now provided with an `ReportCompletionHandler` instance and are expected to call its `onLocationReportComplete()` method after reporting (e.g., uploading.)
