### PR TITLE
Updates to LocationTracer#startTrackingPassively() signatures

### DIFF
--- a/locationtracer/build.gradle
+++ b/locationtracer/build.gradle
@@ -1,15 +1,14 @@
-// Can an Android library be used to generate a JAR instead of an AAR?
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22 // 'android-N'
+    compileSdkVersion 22
     buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 22 // 'N'
+        targetSdkVersion 22
         versionCode 1
-        versionName "1.1.0"
+        versionName "1.2.0"
     }
     buildTypes {
         release {
@@ -43,5 +42,4 @@ android.libraryVariants.all { variant ->
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-//    compile 'com.android.support:appcompat-v7:22.+'
 }

--- a/locationtracer/src/main/java/com/coalminesoftware/locationtracer/LocationTracer.java
+++ b/locationtracer/src/main/java/com/coalminesoftware/locationtracer/LocationTracer.java
@@ -96,9 +96,9 @@ public class LocationTracer<StorageLocation> {
 
 	/**
 	 * Starts passively listening for location updates that happen at the request of other code.
-	 * @param wakeForActiveLocationRequests
+	 * Observed locations will only be stored if it occurred at least a second after the last.
 	 */
-	public void startListeningPassively(boolean wakeForActiveLocationRequests) {
+	public void startListeningPassively() {
 		startListeningPassively(
 				DEFAULT_MINIMUM_LOCATION_UPDATE_INTERVAL_DURATION,
 				DEFAULT_MINIMUM_LOCATION_UPDATE_DISTANCE,
@@ -107,11 +107,33 @@ public class LocationTracer<StorageLocation> {
 	}
 
 	/**
+	 * Starts passively listening for location updates that happen at the request of other code. For a location to be
+	 * stored, it must have occurred at least the given amount of time after the last and be at least the given
+	 * distance away.
+	 *
+	 * @param minimumLocationUpdateIntervalDuration The minimum number of milliseconds that need to have elapsed since
+	 * the last location in order for the new location to be stored.
+	 * @param minimumLocationUpdateDistance The minimum displacement, in meters, that needs to exist between a location
+	 * and the preceding location in order for the new location to be stored.
+	 */
+	public void startListeningPassively(
+			long minimumLocationUpdateIntervalDuration,
+			float minimumLocationUpdateDistance) {
+		startListeningPassively(
+				minimumLocationUpdateIntervalDuration,
+				minimumLocationUpdateDistance,
+				null,
+				false);
+	}
+
+	/**
 	 * Starts passively listening for location updates that happen at the request of other code. If a location update is
 	 * not received within a certain amount of time, a location is actively requested.
-	 * 
-	 * @param minimumLocationUpdateIntervalDuration The minimum number of milliseconds requested between location updates. 
-	 * @param minimumLocationUpdateDistance The minimum displacement, in meters, that needs to exist between a location and the preceding location.
+	 *
+	 * @param minimumLocationUpdateIntervalDuration The minimum number of milliseconds that need to have elapsed since
+	 * the last location in order for the new location to be stored.
+	 * @param minimumLocationUpdateDistance The minimum displacement, in meters, that needs to exist between a location
+	 * and the preceding location in order for the new location to be stored.
 	 * @param activeLocationRequestInterval How long to wait since the last location update before actively requesting another. 
 	 * @param wakeForActiveLocationRequests Whether to wake the device when requesting active location updates.
 	 */


### PR DESCRIPTION
The previous ones only allowed user to start listening passively with the default time/distance and no active updates, or to listen with active updates.
